### PR TITLE
:bug: UserId interpreted as string issue

### DIFF
--- a/src/Services/MaxMindWebService.php
+++ b/src/Services/MaxMindWebService.php
@@ -25,7 +25,7 @@ class MaxMindWebService extends AbstractService
     public function boot()
     {
         $this->client = new Client(
-            $this->config('user_id'),
+            (int) $this->config('user_id'),
             $this->config('license_key'),
             $this->config('locales', ['en'])
         );


### PR DESCRIPTION
Dear team,

I installed the package today and directly faced an issue with the MaxmindWebService service...

```
In Client.php line 83:
GeoIp2\WebService\Client::__construct(): Argument #1 ($accountId) must be of type int, string given, called in /*****/vendor/interaction-design-foundation/laravel-geoip/src/Services/MaxMindWebService.php on line 27 
```
This is because the `$this->config` helper will return a string instead of an integer, as expected by the MaxMind `Client` class. 

I only added a `(int)` before the user ID, so that it is interpreted as an integer :angel: 

I am kind of surprised that this issue didn't raise before... If I am the only one facing this issue, please forget about this Pull Request.

Regards,

Pythagus :bug: