### PR TITLE
Add custom exception on configuration issue

### DIFF
--- a/src/Console/Update.php
+++ b/src/Console/Update.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace InteractionDesignFoundation\GeoIP\Console;
 
 use Illuminate\Console\Command;
+use InteractionDesignFoundation\GeoIP\Exceptions\MissingConfigurationException;
 
 class Update extends Command
 {
@@ -41,7 +42,13 @@ class Update extends Command
     public function fire()
     {
         // Get default service
-        $service = app('geoip')->getService();
+        try {
+            $service = app('geoip')->getService();
+        } catch(MissingConfigurationException $e) {
+            $this->components->error($e->getMessage()) ;
+            
+            return static::FAILURE ;
+        }
 
         // Ensure the selected service supports updating
         if (method_exists($service, 'update') === false) {

--- a/src/Exceptions/MissingConfigurationException.php
+++ b/src/Exceptions/MissingConfigurationException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InteractionDesignFoundation\GeoIP\Exceptions;
+
+use RuntimeException;
+
+class MissingConfigurationException extends RuntimeException {
+
+}

--- a/src/Services/AbstractService.php
+++ b/src/Services/AbstractService.php
@@ -7,6 +7,7 @@ namespace InteractionDesignFoundation\GeoIP\Services;
 use InteractionDesignFoundation\GeoIP\Location;
 use Illuminate\Support\Arr;
 use InteractionDesignFoundation\GeoIP\Contracts\ServiceInterface;
+use InteractionDesignFoundation\GeoIP\Exceptions\MissingConfigurationException;
 
 abstract class AbstractService implements ServiceInterface
 {
@@ -55,5 +56,29 @@ abstract class AbstractService implements ServiceInterface
     public function config($key, $default = null)
     {
         return Arr::get($this->config, $key, $default);
+    }
+
+    /**
+     * This method ensures that the given key was filled
+     * by the user, so that the service can be called without
+     * errors raised linked to missing configuration.
+     * 
+     * @param string|string[] $key
+     * @return void
+     */
+    public function ensureConfigurationParameterDefined($keys) {
+        // Be able to accept a string and an array of strings.
+        $keys = is_string($keys) ? [$keys] : $keys ;
+
+        foreach($keys as $key) {
+            $config = $this->config($key) ;
+
+            // If the config is not defined / is empty.
+            if(empty($config)) {
+                $service = (new \ReflectionClass($this))->getShortName() ;
+                
+                throw new MissingConfigurationException("Missing '$key' parameter (service: $service)") ;
+            }
+        }
     }
 }

--- a/src/Services/IPData.php
+++ b/src/Services/IPData.php
@@ -24,6 +24,8 @@ class IPData extends AbstractService
      */
     public function boot()
     {
+        $this->ensureConfigurationParameterDefined('key') ;
+
         $this->client = new HttpClient([
             'base_uri' => 'https://api.ipdata.co/',
             'query' => [

--- a/src/Services/IPFinder.php
+++ b/src/Services/IPFinder.php
@@ -22,6 +22,8 @@ class IPFinder extends AbstractService
      */
     public function boot()
     {
+        $this->ensureConfigurationParameterDefined('key') ;
+        
         $this->client = new HttpClient([
             'base_uri' => 'https://api.ipfinder.io/v1/',
             'headers' => [

--- a/src/Services/MaxMindDatabase.php
+++ b/src/Services/MaxMindDatabase.php
@@ -24,6 +24,8 @@ class MaxMindDatabase extends AbstractService
      */
     public function boot()
     {
+        $this->ensureConfigurationParameterDefined('database_path') ;
+
         $path = $this->config('database_path');
         assert(is_string($path), 'Invalid "database_path" config value');
 

--- a/src/Services/MaxMindWebService.php
+++ b/src/Services/MaxMindWebService.php
@@ -24,6 +24,8 @@ class MaxMindWebService extends AbstractService
      */
     public function boot()
     {
+        $this->ensureConfigurationParameterDefined(['user_id', 'license_key']) ;
+
         $this->client = new Client(
             $this->config('user_id'),
             $this->config('license_key'),


### PR DESCRIPTION
Dear team,

I faced some "unfriendly" errors because I misconfigured some `env` variables by mistake. After investigating the issue, I found out it was because some environment variables were missing. 

I made this PR to display a friendly message if a configuration parameter is missing.

If you think this is useless, please ignore this PR.

Regards,

Pythagus :bug: