### PR TITLE
Fix: Gracefully handle cache drivers that do not support tagging

### DIFF
--- a/.github/workflows/php-coding-style.yml
+++ b/.github/workflows/php-coding-style.yml
@@ -1,47 +1,71 @@
-name: Coding style
+name: Code Style
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - '**.php'
+      - 'composer.json'
   pull_request:
     paths:
       - '**.php'
-      - '.composer.json'
-      - '.php_cs'
-      - '.github/workflows/php-coding-style.yml'
-  push:
-    paths:
-      - '**.php'
-      - '.composer.json'
-      - '.php_cs'
-      - '.github/workflows/php-coding-style.yml'
-    branches-ignore:
-      - main # protected
+      - 'composer.json'
 
 jobs:
-  style:
+  fix:
+    name: Auto-fix code style
+    # Skip fork PRs — GITHUB_TOKEN can't push to external forks.
+    # Fork contributors: run `composer rector && composer cs` locally.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-
     steps:
-      -   name: Checkout code
-          uses: actions/checkout@v6
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ github.token }}
 
-      -   name: Setup PHP
-          uses: shivammathur/setup-php@v2
-          with:
-            php-version: 8.4
-            coverage: none
-          env:
-            COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          coverage: none
 
-      -   name: Install composer dependencies
-          run: composer install --no-interaction --no-progress --no-scripts
+      - name: Install composer dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
 
-      -   name: Lint facade docblocks
-          run: php -f vendor/bin/facade.php InteractionDesignFoundation\\GeoIP\\Facades\\GeoIP
+      - name: Rector
+        run: composer rector
 
-      -   name: Fix style
-          run: vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --allow-risky=yes
+      - name: PHP CS Fixer
+        run: composer cs
 
-      -   name: Commit changes
-          uses: stefanzweifel/git-auto-commit-action@v7
-          with:
-            commit_message: Fix coding style
+      - name: Commit fixes
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: 'style: auto-fix (rector + php-cs-fixer)'
+          commit_author: 'GitHub Actions <actions@github.com>'
+
+  check:
+    name: Verify code style (forks)
+    # Only run the check job on fork PRs where we can't auto-fix.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          coverage: none
+
+      - name: Install composer dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      - name: Rector (dry-run)
+        run: composer rector:dry
+
+      - name: PHP CS check
+        run: composer cs:check

--- a/.github/workflows/php-coding-style.yml
+++ b/.github/workflows/php-coding-style.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.4
+          php-version: 8.3
           coverage: none
 
       - name: Install composer dependencies
@@ -58,7 +58,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.4
+          php-version: 8.3
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/php-coding-style.yml
+++ b/.github/workflows/php-coding-style.yml
@@ -39,9 +39,7 @@ jobs:
           run: php -f vendor/bin/facade.php InteractionDesignFoundation\\GeoIP\\Facades\\GeoIP
 
       -   name: Fix style
-          uses: docker://oskarstark/php-cs-fixer-ga
-          with:
-            args: --config=.php-cs-fixer.php --allow-risky=yes
+          run: vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --allow-risky=yes
 
       -   name: Commit changes
           uses: stefanzweifel/git-auto-commit-action@v7

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,12 +12,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.5, 8.4, 8.3, 8.2]
+        php: [8.5, 8.4, 8.3]
         laravel: [^12.0, ^13.0]
         dependencies: [lowest, highest]
-        exclude:
-          - laravel: ^13.0
-            php: 8.2
 
     name: P${{ matrix.php }} | L${{ matrix.laravel }} | ${{ matrix.dependencies == 'highest' && '↑' || '↓' }}
 

--- a/composer.json
+++ b/composer.json
@@ -78,6 +78,8 @@
         "phpstan": "vendor/bin/phpstan --level=0 --no-progress analyse --configuration phpstan.neon --memory-limit 2G",
         "psalm": "vendor/bin/psalm",
         "rector": "vendor/bin/rector process --config rector.php ",
+        "rector:dry": "vendor/bin/rector process --config rector.php --dry-run",
+        "cs:check": "@php -d memory_limit=-1 vendor/bin/php-cs-fixer fix --no-interaction --ansi --verbose --dry-run",
         "sa": "@psalm",
         "sa:bl": "@psalm --set-baseline=psalm-baseline.xml",
         "test": "vendor/bin/phpunit"

--- a/config/geoip.php
+++ b/config/geoip.php
@@ -128,8 +128,10 @@ return [
     | Cache Tags
     |--------------------------------------------------------------------------
     |
-    | Cache tags are not supported when using the file or database cache
-    | drivers in Laravel. This is done so that only locations can be cleared.
+    | Cache tags allow you to selectively clear only GeoIP cached locations
+    | without affecting other cached data. If the active cache driver does
+    | not support tagging (e.g. file, database), tags are automatically
+    | ignored at runtime. Set to null or an empty array to disable tagging.
     |
     */
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -71,7 +71,6 @@
     <MixedArgument>
       <code><![CDATA[$config]]></code>
       <code><![CDATA[$this->config('cache_expires', 30)]]></code>
-      <code><![CDATA[$this->config('cache_tags')]]></code>
       <code><![CDATA[$this->config('default_location', [])]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -24,11 +24,9 @@ final class Cache
     /**
      * Create a new cache instance.
      *
-     * @param CacheManager $cache
-     * @param array $tags
-     * @param int $expires
+     * @param list<string> $tags
      */
-    public function __construct(CacheManager $cache, $tags, private readonly int $expires = 30)
+    public function __construct(CacheManager $cache, array $tags, private readonly int $expires = 30)
     {
         $this->cache = ($tags === [] || !$cache->supportsTags()) ? $cache : $cache->tags($tags);
     }

--- a/src/Console/Clear.php
+++ b/src/Console/Clear.php
@@ -40,8 +40,8 @@ class Clear extends Command
      */
     protected function isSupported(): bool
     {
-        return (empty(app('geoip')->config('cache_tags')) === false)
-            && (in_array(config('cache.default'), ['file', 'database'], true) === false);
+        return !empty(app('geoip')->config('cache_tags'))
+            && app(\Illuminate\Cache\CacheManager::class)->supportsTags();
     }
 
     /**

--- a/src/Console/Clear.php
+++ b/src/Console/Clear.php
@@ -24,7 +24,10 @@ class Clear extends Command
     public function handle(): int
     {
         if ($this->isSupported() === false) {
-            $this->output->error('Default cache system does not support tags');
+            $this->output->error(
+                'Cannot selectively clear GeoIP cache: either cache tags are not configured'
+                .' or the active cache driver does not support tagging.'
+            );
             return self::FAILURE;
         }
 

--- a/src/GeoIP.php
+++ b/src/GeoIP.php
@@ -64,9 +64,11 @@ class GeoIP
         private readonly LoggerInterface $logger,
     ) {
         // Create caching instance
+        /** @var list<string> $cacheTags */
+        $cacheTags = array_values((array) $this->config('cache_tags', []));
         $this->cache = new Cache(
             $cache,
-            $this->config('cache_tags'),
+            $cacheTags,
             $this->config('cache_expires', 30)
         );
         $this->cache->setPrefix((string) $this->config('cache_prefix'));

--- a/src/GeoIP.php
+++ b/src/GeoIP.php
@@ -67,7 +67,7 @@ class GeoIP
         /** @var list<string> $cacheTags */
         $cacheTags = array_values((array) $this->config('cache_tags', []));
         if ($cacheTags !== [] && !$cache->supportsTags()) {
-            $this->logger->warning('GeoIP: cache tags are configured but the active cache driver does not support tagging. Tags will be ignored.');
+            $this->logger->info('GeoIP: cache tags are configured but the active cache driver does not support tagging. Tags will be ignored.');
         }
 
         $this->cache = new Cache(

--- a/src/GeoIP.php
+++ b/src/GeoIP.php
@@ -66,6 +66,9 @@ class GeoIP
         // Create caching instance
         /** @var list<string> $cacheTags */
         $cacheTags = array_values((array) $this->config('cache_tags', []));
+        if ($cacheTags !== [] && !$cache->supportsTags()) {
+            $this->logger->warning('GeoIP: cache tags are configured but the active cache driver does not support tagging. Tags will be ignored.');
+        }
         $this->cache = new Cache(
             $cache,
             $cacheTags,

--- a/src/GeoIP.php
+++ b/src/GeoIP.php
@@ -69,6 +69,7 @@ class GeoIP
         if ($cacheTags !== [] && !$cache->supportsTags()) {
             $this->logger->warning('GeoIP: cache tags are configured but the active cache driver does not support tagging. Tags will be ignored.');
         }
+
         $this->cache = new Cache(
             $cache,
             $cacheTags,

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -33,6 +33,25 @@ final class CacheTest extends TestCase
     }
 
     #[Test]
+    public function should_work_without_tags_on_non_tagging_driver(): void
+    {
+        // Simulates file/database cache driver which doesn't support tagging
+        $cache = new Cache(app(CacheManager::class), ['some-tag'], 30);
+        $location = new Location([
+            'ip' => '81.2.69.142',
+            'iso_code' => 'US',
+            'lat' => 41.31,
+            'lon' => -72.92,
+        ]);
+
+        $cache->set($location['ip'], $location);
+        $cachedLocation = $cache->get($location['ip']);
+
+        $this->assertInstanceOf(Location::class, $cachedLocation);
+        $this->assertSame('81.2.69.142', $cachedLocation->ip);
+    }
+
+    #[Test]
     public function it_flushes_empty_cache(): void
     {
         $cache = new Cache(app(CacheManager::class), [], 30);

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -33,10 +33,17 @@ final class CacheTest extends TestCase
     }
 
     #[Test]
-    public function should_work_without_tags_on_non_tagging_driver(): void
+    public function should_fall_back_to_untagged_cache_when_driver_does_not_support_tags(): void
     {
-        // Simulates file/database cache driver which doesn't support tagging
-        $cache = new Cache(app(CacheManager::class), ['some-tag'], 30);
+        // Switch to file driver which does not support tagging
+        config(['cache.default' => 'file']);
+        $cacheManager = app(CacheManager::class);
+
+        $this->assertFalse($cacheManager->supportsTags(), 'File cache driver should not support tags');
+
+        // Tags are configured, but driver doesn't support them — should not throw
+        $cache = new Cache($cacheManager, ['some-tag'], 30);
+
         $location = new Location([
             'ip' => '81.2.69.142',
             'iso_code' => 'US',


### PR DESCRIPTION
## Context

When the default cache driver does not support tagging (e.g. `file`, `database`), but `cache_tags` is configured (which is the default), the `geoip:clear` command fails with a misleading error. Additionally, there is no indication to the developer that their tag configuration is being silently ignored at runtime.

This is the same issue reported in Torann/laravel-geoip#255, but addressed more robustly at the code level rather than with a config-level workaround.

## Solution

- **Type the `Cache` constructor `$tags` parameter** as `array` with a `@param list<string>` annotation, replacing the untyped parameter
- **Normalize `cache_tags` config** in `GeoIP` constructor using `array_values((array) ...)` so `null` or missing values safely become an empty array instead of causing errors
- **Log a warning** when cache tags are configured but the active driver does not support tagging, so developers can discover the mismatch through logs
- **Replace the hardcoded driver list** (`['file', 'database']`) in `Clear::isSupported()` with a dynamic `supportsTags()` check that covers all current and future non-tagging drivers
- **Improve the `geoip:clear` error message** to explain why selective clearing is unavailable
- **Add a test** that uses the `file` cache driver to genuinely exercise the fallback path
- **Update the config comment** to document the auto-fallback behavior and the option to set `cache_tags` to `null`
